### PR TITLE
set default flushSize to 10

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -43,7 +43,7 @@ const LEVEL_NAMES = {
 } as const;
 
 export default function (opts: PinoSplunkOptions) {
-  opts.flushSize ??= 2;
+  opts.flushSize ??= 10;
   opts.flushIntervalMs ??= 10000;
   opts.path ??= '/services/collector/event';
 


### PR DESCRIPTION
It should have been 10, as in the documentation, but it was set to 2 😓 